### PR TITLE
Change error handleling when database fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The API is available at `http://localhost:4444` (or the port specified in your e
 
 ### Get All Artworks
 
-- **URL:** `http://localhost:4444/artworks`
+- **PATH:** `/artworks`
 - **Method:** `GET`
 - **Successful Response:**
   [
@@ -63,7 +63,16 @@ The API is available at `http://localhost:4444` (or the port specified in your e
 In case of errors, the API will return responses in the following format:
 
 - **Error Response:**
-  - `error`: Descriptive error message
+  - `error`: (Descriptive error message)
+
+And will log the errors, with extended information in the following format:
+
+- **Error in response:**_background color magenta_
+
+  - Responded with ERROR: (Received error)
+
+- **Error in execution:**_background color red_
+  - Failed to (what failed): (error message)
 
 ## Contribution
 

--- a/src/artwork/controller/ArtworksController.ts
+++ b/src/artwork/controller/ArtworksController.ts
@@ -1,12 +1,11 @@
 import { type NextFunction, type Request, type Response } from "express";
 import { type ArtworksControllerStructure } from "./types";
-import { type ArtworksRepositoryStructure } from "../repository/types";
+import { type ArtworksRepository } from "../repository/types";
 import ServerError from "../../server/middlewares/errors/ServerError/ServerError.js";
+import chalk from "chalk";
 
 class ArtworksController implements ArtworksControllerStructure {
-  constructor(
-    private readonly artworksRepository: ArtworksRepositoryStructure,
-  ) {}
+  constructor(private readonly artworksRepository: ArtworksRepository) {}
 
   getArtworks = async (
     _req: Request,
@@ -18,7 +17,11 @@ class ArtworksController implements ArtworksControllerStructure {
 
       res.status(200).json(artworks);
     } catch (error) {
-      const serverError = new ServerError((error as Error).message, 404);
+      console.log(
+        chalk.bgRed.bold.white((error as { message: string }).message),
+      );
+
+      const serverError = new ServerError("Failed to find Artworks", 500);
 
       next(serverError);
     }

--- a/src/artwork/controller/__tests__/getArtworks.test.ts
+++ b/src/artwork/controller/__tests__/getArtworks.test.ts
@@ -1,22 +1,24 @@
 import { type NextFunction, type Request, type Response } from "express";
-import { type ArtworksRepositoryStructure } from "../../repository/types";
+import { type ArtworksRepository } from "../../repository/types";
 import ArtworksController from "../ArtworksController";
-import type ArtworkStructure from "../../types";
 import ServerError from "../../../server/middlewares/errors/ServerError/ServerError";
+import { type ResponseWithStatusJson } from "../types";
+import type ArtworkStructure from "../../types";
 
-describe("Given the getartworks method from artworksController", () => {
+describe("Given the getArtworks method from artworksController", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   const req = {};
-  const res: Partial<Response> = {
+
+  const res: ResponseWithStatusJson = {
     status: jest.fn().mockReturnThis(),
     json: jest.fn(),
   };
   const next = jest.fn();
 
-  describe("When it receives a Request and the repository contains the artwork 'La maja desnuda' by iker", () => {
+  describe("When it receives a Request and the repository contains the artwork 'La maja desnuda'", () => {
     const artworks: ArtworkStructure[] = [
       {
         _id: "",
@@ -30,7 +32,7 @@ describe("Given the getartworks method from artworksController", () => {
       },
     ];
 
-    const repository: ArtworksRepositoryStructure = {
+    const repository: ArtworksRepository = {
       async getAll(): Promise<ArtworkStructure[]> {
         return artworks;
       },
@@ -49,7 +51,7 @@ describe("Given the getartworks method from artworksController", () => {
       expect(res.status).toHaveBeenCalledWith(expectedStatus);
     });
 
-    test("Then it should call the response json method with a list of artworks including 'La maja desnuda' by iker", async () => {
+    test("Then it should call the response json method with a list of artworks including 'La maja desnuda' ", async () => {
       await controller.getArtworks(
         req as Request,
         res as Response,
@@ -60,17 +62,17 @@ describe("Given the getartworks method from artworksController", () => {
     });
   });
 
-  describe("When it receives a Next function and the repository throws an error with the message 'Failed to get artworks' ", () => {
-    const repository: ArtworksRepositoryStructure = {
+  describe("When it receives a Next function and the repository throws an error ", () => {
+    const repository: ArtworksRepository = {
       async getAll(): Promise<ArtworkStructure[]> {
-        throw new Error("Failed to get artworks");
+        throw new Error();
       },
     };
     const controller = new ArtworksController(repository);
 
-    test("Then it should call the next function with a server error with the code 404 and the message 'Failed to get artworks'", async () => {
+    test("Then it should call the next function with a server error with the code 404 and the message 'Failed to find artworks'", async () => {
       const expectedStatus = 404;
-      const expectedMessage = "Failed to get artworks";
+      const expectedMessage = "Failed to find Artworks";
 
       const error = new ServerError(expectedMessage, expectedStatus);
 

--- a/src/artwork/controller/types.ts
+++ b/src/artwork/controller/types.ts
@@ -3,3 +3,5 @@ import { type NextFunction, type Request, type Response } from "express";
 export interface ArtworksControllerStructure {
   getArtworks(req: Request, res: Response, next: NextFunction): void;
 }
+
+export type ResponseWithStatusJson = Pick<Response, "status" | "json">;

--- a/src/artwork/repository/ArtworksRepository.ts
+++ b/src/artwork/repository/ArtworksRepository.ts
@@ -1,17 +1,11 @@
 import { type Model } from "mongoose";
-import { type ArtworksRepositoryStructure } from "./types.js";
+import { type ArtworksRepository } from "./types.js";
 import type ArtworkStructure from "../types.js";
 
-class ArtworksRepository implements ArtworksRepositoryStructure {
+class ArtworksMongooseRepository implements ArtworksRepository {
   constructor(public readonly model: Model<ArtworkStructure>) {}
 
-  getAll = async (): Promise<ArtworkStructure[]> => {
-    try {
-      return await this.model.find().exec();
-    } catch {
-      throw new Error("Failed to find Artworks");
-    }
-  };
+  getAll = async (): Promise<ArtworkStructure[]> => this.model.find().exec();
 }
 
-export default ArtworksRepository;
+export default ArtworksMongooseRepository;

--- a/src/artwork/repository/types.ts
+++ b/src/artwork/repository/types.ts
@@ -1,5 +1,5 @@
 import type ArtworkStructure from "../types.js";
 
-export interface ArtworksRepositoryStructure {
+export interface ArtworksRepository {
   getAll(): Promise<ArtworkStructure[]>;
 }

--- a/src/artwork/router/__tests__/getArtoworksEndpoint.test.ts
+++ b/src/artwork/router/__tests__/getArtoworksEndpoint.test.ts
@@ -7,11 +7,15 @@ import app from "../../../server/app/app";
 import type ArtworkStructure from "../../types";
 
 let mongoMemoryServer: MongoMemoryServer;
-
+let serverUri: string;
 beforeAll(async () => {
   mongoMemoryServer = await MongoMemoryServer.create();
-  const serverUri = mongoMemoryServer.getUri();
+  serverUri = mongoMemoryServer.getUri();
+
   await connectToDataBase(serverUri);
+});
+beforeEach(async () => {
+  await Artwork.deleteMany();
 });
 
 afterAll(async () => {
@@ -51,7 +55,7 @@ describe("Given the GET /artworks endpoint", () => {
 
       const expectedStatusCode = 200;
       const expectedArtwork = {
-        title: "the mona Lisa",
+        title: monaLisa.title,
       };
 
       await Artwork.create(monaLisa, vitruvisMan);
@@ -67,10 +71,10 @@ describe("Given the GET /artworks endpoint", () => {
   });
 
   describe("When it receives a Request, and the data base fails", () => {
-    test("Then it should respond wiht an blabla error ", async () => {
+    test("Then it should respond wiht an error: 'Failed to find Artworks' ", async () => {
       await mongoose.disconnect();
 
-      const expectedStatusCode = 404;
+      const expectedStatusCode = 500;
       const expectedErrorMessage = "Failed to find Artworks";
 
       const response = await request(app).get(path).expect(expectedStatusCode);
@@ -78,6 +82,8 @@ describe("Given the GET /artworks endpoint", () => {
       const body = response.body as { error: string };
 
       expect(body.error).toBe(expectedErrorMessage);
+
+      await mongoose.connect(serverUri);
     });
   });
 });

--- a/src/artwork/router/artworkRouter.ts
+++ b/src/artwork/router/artworkRouter.ts
@@ -1,11 +1,11 @@
 import { Router } from "express";
 import ArtworksController from "../controller/ArtworksController.js";
-import ArtworksRepository from "../repository/ArtworksRepository.js";
+import ArtworksMongooseRepository from "../repository/ArtworksRepository.js";
 import Artwork from "../model/Artwork.js";
 
 const artworkRouter = Router();
 
-const artworkRepository = new ArtworksRepository(Artwork);
+const artworkRepository = new ArtworksMongooseRepository(Artwork);
 
 const artworksController = new ArtworksController(artworkRepository);
 

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -4,11 +4,15 @@ import chalk from "chalk";
 const connectToDataBase = async (dataBaseUrl: string): Promise<void> => {
   try {
     await mongoose.connect(dataBaseUrl);
+
     console.log(chalk.greenBright("Gracefully connected to Database "));
   } catch (error) {
+    const errorMessage = (error as { message: string }).message;
+
     console.log(
-      chalk.red("failed to connect to DataBase: ") +
-        (error as { message: string }).message,
+      chalk.bgRed.white.bold(
+        `"Failed to connect to DataBase: "${errorMessage}`,
+      ),
     );
   }
 };

--- a/src/server/app/app.ts
+++ b/src/server/app/app.ts
@@ -7,11 +7,12 @@ import cors from "cors";
 import morgan from "morgan";
 
 const app = express();
+
 app.use(morgan("dev"));
 
 app.use(
   cors({
-    origin: (process.env.ORIGIN ?? "").split(","),
+    origin: (process.env.ORIGINS ?? "").split(","),
   }),
 );
 

--- a/src/server/middlewares/generalError.ts
+++ b/src/server/middlewares/generalError.ts
@@ -11,7 +11,9 @@ export const generalError = (
   const statusCode = error.statusCode ?? 500;
   const errorMessage = error.message || "Server failed: Unknown Error";
 
-  console.log(chalk.redBright.bold(`${errorMessage}`));
+  console.log(
+    chalk.bold.white.bgMagenta(`Responded with ERROR:${errorMessage}`),
+  );
 
   res.status(statusCode).json({ error: `${errorMessage}` });
 };


### PR DESCRIPTION
When the database responds with an error, 
this error will be logged in `cli `and the api rest will respond with `failed to (what failed) `for example : _Failed to get artworks_

Added errors info to README