### PR TITLE
Disable x-powered-by in app

### DIFF
--- a/src/server/app/app.ts
+++ b/src/server/app/app.ts
@@ -7,6 +7,7 @@ import cors from "cors";
 import morgan from "morgan";
 
 const app = express();
+app.disable("x-powered-by");
 
 app.use(morgan("dev"));
 


### PR DESCRIPTION
se ha inhabilitado el header 'x-powered-by' para reforzar al seguridad de la app