### PR TITLE
Add createArtwork to artworksMongooseRepository

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start:dev": "node --watch .",
     "prepare": "husky",
     "test": "jest",
-    "test:dev": "jest --watcAll",
+    "test:dev": "jest --watchAll",
     "test:coverage": "jest --coverage"
   },
   "keywords": [],

--- a/src/artwork/controller/__tests__/getArtworks.test.ts
+++ b/src/artwork/controller/__tests__/getArtworks.test.ts
@@ -1,5 +1,8 @@
 import { type NextFunction, type Request, type Response } from "express";
-import { type ArtworksRepository } from "../../repository/types";
+import {
+  type ArtworkData,
+  type ArtworksRepository,
+} from "../../repository/types";
 import ArtworksController from "../ArtworksController";
 import ServerError from "../../../server/middlewares/errors/ServerError/ServerError";
 import { type ResponseWithStatusJson } from "../types";
@@ -38,6 +41,9 @@ describe("Given the getArtworks method from artworksController", () => {
       async getAll(): Promise<ArtworkStructure[]> {
         return artworks;
       },
+      async createArtwork(artowrkData: ArtworkData): Promise<ArtworkStructure> {
+        throw new Error("Function not implemented.");
+      },
     };
     const controller = new ArtworksController(repository);
 
@@ -68,6 +74,9 @@ describe("Given the getArtworks method from artworksController", () => {
     const repository: ArtworksRepository = {
       async getAll(): Promise<ArtworkStructure[]> {
         throw new Error();
+      },
+      async createArtwork(artowrkData: ArtworkData): Promise<ArtworkStructure> {
+        throw new Error("Function not implemented.");
       },
     };
     const controller = new ArtworksController(repository);

--- a/src/artwork/repository/ArtworksRepository.ts
+++ b/src/artwork/repository/ArtworksRepository.ts
@@ -1,11 +1,13 @@
 import { type Model } from "mongoose";
-import { type ArtworksRepository } from "./types.js";
+import { type ArtworkData, type ArtworksRepository } from "./types.js";
 import type ArtworkStructure from "../types.js";
 
 class ArtworksMongooseRepository implements ArtworksRepository {
   constructor(public readonly model: Model<ArtworkStructure>) {}
 
   getAll = async (): Promise<ArtworkStructure[]> => this.model.find().exec();
+  createArtwork = async (artworkData: ArtworkData): Promise<ArtworkStructure> =>
+    this.model.create(artworkData);
 }
 
 export default ArtworksMongooseRepository;

--- a/src/artwork/repository/types.ts
+++ b/src/artwork/repository/types.ts
@@ -2,4 +2,7 @@ import type ArtworkStructure from "../types.js";
 
 export interface ArtworksRepository {
   getAll(): Promise<ArtworkStructure[]>;
+  createArtwork(artowrkData: ArtworkData): Promise<ArtworkStructure>;
 }
+
+export type ArtworkData = Omit<ArtworkStructure, "_id" | "isFavourite">;


### PR DESCRIPTION
se añadio el metodo `createArtwork` al repositorio de artworks, 
se ha creado el tipo `artworkData`, que es un _utility type_ de` ArtworkStructure`, que omite `_id` y `isFavourite`, que son los daots que no se necesitan para crear un `Artwork` nuevo