### PR TITLE
Change getAll response to object

### DIFF
--- a/src/artwork/controller/ArtworksController.ts
+++ b/src/artwork/controller/ArtworksController.ts
@@ -17,7 +17,7 @@ class ArtworksController implements ArtworksControllerStructure {
     try {
       const artworks = await this.artworksRepository.getAll();
 
-      res.status(200).json(artworks);
+      res.status(200).json({ artworks });
     } catch (error) {
       console.log(
         chalk.bgRed.bold.white((error as { message: string }).message),

--- a/src/artwork/controller/__tests__/ArtworksController.test.ts
+++ b/src/artwork/controller/__tests__/ArtworksController.test.ts
@@ -68,7 +68,7 @@ describe("Given the getArtworks method from artworksController", () => {
         next as NextFunction,
       );
 
-      expect(res.json).toHaveBeenCalledWith(artworks);
+      expect(res.json).toHaveBeenCalledWith({ artworks });
     });
   });
 

--- a/src/artwork/router/__tests__/artworkRouter.test.ts
+++ b/src/artwork/router/__tests__/artworkRouter.test.ts
@@ -5,6 +5,7 @@ import connectToDataBase from "../../../database";
 import Artwork from "../../model/Artwork";
 import app from "../../../server/app/app";
 import type ArtworkStructure from "../../types";
+
 import { type ArtworkData } from "../../repository/types";
 
 let mongoMemoryServer: MongoMemoryServer;
@@ -67,9 +68,9 @@ describe("Given the GET /artworks endpoint", () => {
 
       const response = await request(app).get(path).expect(expectedStatusCode);
 
-      const body = response.body as ArtworkStructure[];
+      const body = response.body as { artworks: ArtworkStructure[] };
 
-      expect(body).toEqual(
+      expect(body.artworks).toEqual(
         expect.arrayContaining([expect.objectContaining(expectedArtwork)]),
       );
     });


### PR DESCRIPTION
se ha cambiado  la response para la solicitudes  a `GET /artworks` , de un array de artworks a un objeto con la propiedad artworks que apunta a la lista de artworks
`{artworks: artwork[]}`