### PR TITLE
Fix createArtwork responses body and eliminate version from model

### DIFF
--- a/IsayArt.postman_collection.json
+++ b/IsayArt.postman_collection.json
@@ -27,7 +27,7 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\r\n  \"title\": \"the mona Lisa\",\r\n  \"author\": \"Leonardo da vinci\",\r\n  \"description\": \"painting of La Gioconda smiling\",\r\n  \"year\": 2024,\r\n  \"artworkUrl\": \"https://art.com/\",\r\n  \"size\": {\r\n    \"width\": 40,\r\n    \"height\": 60\r\n  },\r\n  \"location\": \"madrid\",\r\n  \"medium\": \"odio sobre lienzo\"\r\n}",
+          "raw": "{\r\n  \"title\": \"the mona Lisa\",\r\n  \"author\": \"Leonardo da vinci\",\r\n  \"description\": \"painting of La Gioconda smiling\",\r\n  \"year\": 2024,\r\n  \"artworkUrl\": \"https://media.revistaad.es/photos/60c2230c899238f7fd38d143/1:1/w_2030,h_2030,c_limit/281373.jpg\",\r\n  \"size\": {\r\n    \"width\": 40,\r\n    \"height\": 60\r\n  },\r\n  \"location\": \"madrid\",\r\n  \"medium\": \"odio sobre lienzo\"\r\n}",
           "options": {
             "raw": {
               "language": "json"

--- a/src/artwork/controller/ArtworksController.ts
+++ b/src/artwork/controller/ArtworksController.ts
@@ -37,7 +37,7 @@ class ArtworksController implements ArtworksControllerStructure {
     try {
       const newArtwork = await this.artworksRepository.createArtwork(req.body);
 
-      res.status(200).json(newArtwork);
+      res.status(200).json({ newArtwork });
     } catch (error) {
       const errorCode = (error as { code: number }).code;
 

--- a/src/artwork/controller/__tests__/ArtworksController.test.ts
+++ b/src/artwork/controller/__tests__/ArtworksController.test.ts
@@ -21,7 +21,7 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-const majaDesnuda = {
+const majaDesnuda: ArtworkStructure = {
   _id: "",
   title: "La maja desnuda",
   author: "iker",
@@ -33,6 +33,7 @@ const majaDesnuda = {
   medium: "oleo sobre lienzo",
   location: "Madrid, España",
 };
+
 describe("Given the getArtworks method from artworksController", () => {
   const req = {};
 

--- a/src/artwork/controller/__tests__/ArtworksController.test.ts
+++ b/src/artwork/controller/__tests__/ArtworksController.test.ts
@@ -133,7 +133,7 @@ describe("Given the createArtwork method from artworksController", () => {
         next as NextFunction,
       );
 
-      expect(res.json).toHaveBeenCalledWith(majaDesnuda);
+      expect(res.json).toHaveBeenCalledWith({ newArtwork: majaDesnuda });
     });
 
     test("Then it should call the response status method with '200'", async () => {

--- a/src/artwork/model/Artwork.ts
+++ b/src/artwork/model/Artwork.ts
@@ -1,34 +1,37 @@
 import mongoose, { Schema } from "mongoose";
 import type ArtworkStructure from "../types";
 
-const artworkSchema = new Schema<ArtworkStructure>({
-  title: {
-    type: String,
-    unique: true,
-    required: true,
+const artworkSchema = new Schema<ArtworkStructure>(
+  {
+    title: {
+      type: String,
+      unique: true,
+      required: true,
+    },
+    author: {
+      type: String,
+    },
+    description: {
+      type: String,
+    },
+    year: {
+      type: Number,
+    },
+    artworkUrl: {
+      type: String,
+      required: true,
+    },
+    size: {
+      width: Number,
+      height: Number,
+    },
+    isFavourite: {
+      type: Boolean,
+      default: false,
+    },
   },
-  author: {
-    type: String,
-  },
-  description: {
-    type: String,
-  },
-  year: {
-    type: Number,
-  },
-  artworkUrl: {
-    type: String,
-    required: true,
-  },
-  size: {
-    width: Number,
-    height: Number,
-  },
-  isFavourite: {
-    type: Boolean,
-    default: false,
-  },
-});
+  { versionKey: false },
+);
 
 const Artwork = mongoose.model("Artwork", artworkSchema, "artworks");
 

--- a/src/artwork/router/__tests__/artworkRouter.test.ts
+++ b/src/artwork/router/__tests__/artworkRouter.test.ts
@@ -5,7 +5,6 @@ import connectToDataBase from "../../../database";
 import Artwork from "../../model/Artwork";
 import app from "../../../server/app/app";
 import type ArtworkStructure from "../../types";
-
 import { type ArtworkData } from "../../repository/types";
 
 let mongoMemoryServer: MongoMemoryServer;
@@ -75,24 +74,6 @@ describe("Given the GET /artworks endpoint", () => {
       );
     });
   });
-
-  describe("When it receives a Request, and the data base fails", () => {
-    test("Then it should respond wiht an error: 'Failed to find Artworks' ", async () => {
-      await mongoose.disconnect();
-      await connectToDataBase("wrongUri");
-
-      const expectedStatusCode = 500;
-      const expectedErrorMessage = "Failed to find Artworks";
-
-      const response = await request(app).get(path).expect(expectedStatusCode);
-
-      const body = response.body as { error: string };
-
-      expect(body.error).toBe(expectedErrorMessage);
-
-      await mongoose.connect(serverUri);
-    });
-  });
 });
 
 describe("Given the POST /artworks endpoint", () => {
@@ -103,10 +84,12 @@ describe("Given the POST /artworks endpoint", () => {
       };
       const response = await request(app).post(path).send(monaLisa).expect(200);
 
-      const body = response.body as ArtworkStructure;
+      const body = response.body as { newArtwork: ArtworkStructure };
 
-      expect(body).toHaveProperty("_id");
-      expect(body).toEqual(expect.objectContaining(expectedArtworkTitle));
+      expect(body.newArtwork).toHaveProperty("_id");
+      expect(body.newArtwork).toEqual(
+        expect.objectContaining(expectedArtworkTitle),
+      );
     });
   });
 
@@ -117,7 +100,7 @@ describe("Given the POST /artworks endpoint", () => {
 
       const response = await request(app).post(path).send(monaLisa).expect(409);
 
-      const body = response.body as ArtworkStructure;
+      const body = response.body as { newArtwork: ArtworkStructure };
 
       expect(body).toEqual({ error: expectedErrorMessage });
     });

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1,5 +1,6 @@
 import mongoose from "mongoose";
 import chalk from "chalk";
+import { exit } from "process";
 
 const connectToDataBase = async (dataBaseUrl: string): Promise<void> => {
   try {
@@ -14,6 +15,8 @@ const connectToDataBase = async (dataBaseUrl: string): Promise<void> => {
         `"Failed to connect to DataBase: "${errorMessage}`,
       ),
     );
+
+    exit(1);
   }
 };
 


### PR DESCRIPTION
el cuerpo de la response de createArtowork ahora es un objeto 
`{newArtwork:{artworkcreada}`
tb se ha eliminado la versionKey del schema
y si falla la conexion a la base de datos, se hace un exit code 1
