### PR TITLE
Change update method to findByIdAndUpdate

### DIFF
--- a/IsayArt.postman_collection.json
+++ b/IsayArt.postman_collection.json
@@ -44,27 +44,13 @@
       "response": []
     },
     {
-      "name": "borrarMonalisa",
-      "request": {
-        "method": "DELETE",
-        "header": [],
-        "url": {
-          "raw": "https://clara-fernandez-202403-back.onrender.com/artworks/665ce6c919b649e012a2efe2",
-          "protocol": "https",
-          "host": ["clara-fernandez-202403-back", "onrender", "com"],
-          "path": ["artworks", "665ce6c919b649e012a2efe2"]
-        }
-      },
-      "response": []
-    },
-    {
       "name": "updateMonalisa",
       "request": {
-        "method": "PUT",
+        "method": "PATCH",
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\"_id\":\"667292933cb867c5e6787965\",\r\n\"modification\":{\r\n    \"title\": \"La Gioconda de Madrid\"\r\n}}",
+          "raw": "{\"_id\":\"66572c92b1ee64ca1406557b\",\r\n\"update\":{\r\n    \"isFavourite\": false\r\n}}",
           "options": {
             "raw": {
               "language": "json"
@@ -76,6 +62,20 @@
           "protocol": "https",
           "host": ["clara-fernandez-202403-back", "onrender", "com"],
           "path": ["artworks"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "borrarMonalisa",
+      "request": {
+        "method": "DELETE",
+        "header": [],
+        "url": {
+          "raw": "https://clara-fernandez-202403-back.onrender.com/artworks/665ce6c919b649e012a2efe2",
+          "protocol": "https",
+          "host": ["clara-fernandez-202403-back", "onrender", "com"],
+          "path": ["artworks", "665ce6c919b649e012a2efe2"]
         }
       },
       "response": []

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The API is available at `http://localhost:4444` (or the port specified in your e
 ## Update Artwork
 
 - **PATH:** `/artworks`
-- **Method:** `PUT`
+- **Method:** `PATCH`
 - **Request example:**
 
 ```json

--- a/src/artwork/controller/ArtworksController.ts
+++ b/src/artwork/controller/ArtworksController.ts
@@ -61,12 +61,12 @@ class ArtworksController implements ArtworksControllerStructure {
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { artworkId } = req.body;
+    const { _id } = req.body;
     const { update } = req.body;
 
     try {
       const updatedArtwork = await this.artworksRepository.updateArtwork(
-        artworkId,
+        _id,
         update,
       );
 

--- a/src/artwork/controller/__tests__/ArtworksController.test.ts
+++ b/src/artwork/controller/__tests__/ArtworksController.test.ts
@@ -52,7 +52,7 @@ const errorRepository: ArtworksRepository = {
     throw new Error(`Could not find artwork with ID: ${artworkId}`);
   },
   async updateArtwork(
-    _artworkId: { _id: string },
+    _artworkId: string,
     _modificaton: Partial<ArtworkStructure>,
   ): Promise<ArtworkStructure> {
     throw new Error("Function not implemented.");
@@ -84,11 +84,11 @@ const repository: ArtworksRepository = {
   },
 
   async updateArtwork(
-    artworkId: { _id: string },
+    artworkId: string,
     modificaton: Partial<ArtworkStructure>,
   ): Promise<ArtworkStructure> {
     artworks.map((artwork) => {
-      if (artwork._id === artworkId._id) {
+      if (artwork._id === artworkId) {
         const updatedArtwork = Object.assign(artwork, modificaton);
         return updatedArtwork;
       }
@@ -304,7 +304,7 @@ describe("Given the updateArtwork method from the artworksController", () => {
     const newTitle = "la maja vestidoa";
     const req: Partial<RequestWithUpdateArtworkData> = {
       body: {
-        artworkId: { _id: majaDesnuda._id },
+        _id: majaDesnuda._id,
         update: { title: newTitle },
       },
     };
@@ -334,7 +334,7 @@ describe("Given the updateArtwork method from the artworksController", () => {
 
     const req: Partial<RequestWithUpdateArtworkData> = {
       body: {
-        artworkId: { _id: majaDesnuda._id },
+        _id: majaDesnuda._id,
         update: { year: newYear },
       },
     };

--- a/src/artwork/controller/types.ts
+++ b/src/artwork/controller/types.ts
@@ -26,6 +26,6 @@ export type RequestWithUpdateArtworkData = Request<
   UpdateArtworkData
 >;
 export interface UpdateArtworkData {
-  artworkId: { _id: string };
+  _id: string;
   update: Partial<ArtworkStructure>;
 }

--- a/src/artwork/repository/ArtworksMongooseRepository.ts
+++ b/src/artwork/repository/ArtworksMongooseRepository.ts
@@ -14,17 +14,17 @@ class ArtworksMongooseRepository implements ArtworksRepository {
   }
 
   async updateArtwork(
-    artworkId: { _id: string },
+    artworkId: string,
     update: Partial<ArtworkStructure>,
   ): Promise<ArtworkStructure> {
     const filter = artworkId;
 
-    const updatedArtwork = await this.model.findOneAndUpdate(filter, update, {
+    const updatedArtwork = await this.model.findByIdAndUpdate(filter, update, {
       new: true,
     });
 
     if (!updatedArtwork) {
-      throw new Error(`Could not modify artwork with ID: ${artworkId._id}`);
+      throw new Error(`Could not modify artwork with ID: ${artworkId}`);
     }
 
     return updatedArtwork;

--- a/src/artwork/repository/types.ts
+++ b/src/artwork/repository/types.ts
@@ -4,7 +4,7 @@ export interface ArtworksRepository {
   getAll(): Promise<ArtworkStructure[]>;
   createArtwork(artworkData: ArtworkData): Promise<ArtworkStructure>;
   updateArtwork(
-    artworkId: { _id: string },
+    artworkId: string,
     modification: Partial<ArtworkStructure>,
   ): Promise<ArtworkStructure>;
   deleteById(artworkId: string): Promise<ArtworkStructure | Error>;

--- a/src/artwork/router/__tests__/artworkRouter.test.ts
+++ b/src/artwork/router/__tests__/artworkRouter.test.ts
@@ -211,7 +211,7 @@ describe("Given the GET /artworks/:artworkId endpoint", () => {
   });
 });
 
-describe("Given the PUT /artworks endpoint", () => {
+describe("Given the PATCH /artworks endpoint", () => {
   describe("When it receives  Request with the 'monaLisaId' and isFavourite:true", () => {
     test("Then it should respond with  200 and the updatedArtworkd: monalisa with the property isFavourite:false", async () => {
       const monaLisa = (
@@ -221,7 +221,7 @@ describe("Given the PUT /artworks endpoint", () => {
       const newIsFavouriteValue = true;
       const expectedStatus = 200;
 
-      const artworkId = { _id: monaLisa._id.toString() };
+      const _id = monaLisa._id.toString();
       const update = { isFavourite: newIsFavouriteValue };
 
       const updatedMonalisa: ArtworkStructure = {
@@ -231,12 +231,12 @@ describe("Given the PUT /artworks endpoint", () => {
       };
 
       const requestBody: UpdateArtworkData = {
-        artworkId,
+        _id,
         update,
       };
 
       const response = await request(app)
-        .put(path)
+        .patch(path)
         .send(requestBody)
         .expect(expectedStatus);
 
@@ -255,16 +255,16 @@ describe("Given the PUT /artworks endpoint", () => {
       const expectedStatus = 409;
       const expectedError = "Failed to modify Artwork";
 
-      const artworkId = { _id: wrongId };
+      const _id = wrongId;
       const update = { isFavourite: newIsFavouriteValue };
 
       const requestBody: UpdateArtworkData = {
-        artworkId,
+        _id,
         update,
       };
 
       const response = await request(app)
-        .put(path)
+        .patch(path)
         .send(requestBody)
         .expect(expectedStatus);
 

--- a/src/artwork/router/artworkRouter.ts
+++ b/src/artwork/router/artworkRouter.ts
@@ -11,7 +11,7 @@ const artworksController = new ArtworksController(artworkRepository);
 
 artworkRouter.get("/", artworksController.getArtworks);
 artworkRouter.get("/:artworkId", artworksController.getArtworkById);
-artworkRouter.put("/", artworksController.updateArtwork);
+artworkRouter.patch("/", artworksController.updateArtwork);
 artworkRouter.post("/", artworksController.createArtwork);
 artworkRouter.delete("/:artworkId", artworksController.deleteArtworkById);
 


### PR DESCRIPTION
se ha actualizado el método utilizado para la actualización de datos a` findByIdAndUpdate`, el cual es más específico y adecuado para esta operación.

se ha corregido el método del `Endpoint`, cambiando de `PUT` a` PATCH`, ya que `PATCH` es más apropiado para la actualización parcial de recursos.

ademas han actualizado las colecciones de `Postman` y la documentación en el archivo` README `para reflejar los cambios realizados.